### PR TITLE
Add resend email sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.6",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "resend": "latest"
   },
   "devDependencies": {
     "@types/react": "^19",

--- a/src/GiftMatcher.tsx
+++ b/src/GiftMatcher.tsx
@@ -45,7 +45,7 @@ export function GiftMatcher({ onBack }: { onBack: () => void }) {
     return arr;
   };
 
-  const handleMatch = () => {
+  const handleMatch = async () => {
     const n = persons.length;
     const indices = Array.from({ length: n }, (_, i) => i);
 
@@ -61,6 +61,17 @@ export function GiftMatcher({ onBack }: { onBack: () => void }) {
       }
       if (valid) {
         setMatches(shuffled);
+
+        try {
+          await fetch("/api/sendEmails", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ persons, matches: shuffled }),
+          });
+        } catch (err) {
+          console.error(err);
+        }
+
         return;
       }
     }


### PR DESCRIPTION
## Summary
- send match emails through Resend after pressing Match
- expose backend API to send emails
- include Resend package as dependency

## Testing
- `bun install` *(fails: GET https://registry.npmjs.org/resend - 403)*
- `bun x tsc --noEmit` *(fails to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_6861463894588333b16b0d293d1a09d8