### PR TITLE
Add form persistence and cleanups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,50 +1,8 @@
-import { useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { APITester } from "./APITester";
 import GiftMatcher from "./GiftMatcher";
 import "./index.css";
 
-import logo from "./logo.svg";
-import reactLogo from "./react.svg";
-
 export function App() {
-  const [page, setPage] = useState<"home" | "matcher">("home");
-
-  if (page === "matcher") {
-    return <GiftMatcher onBack={() => setPage("home")}></GiftMatcher>;
-  }
-
-  return (
-    <div className="container mx-auto p-8 text-center relative z-10">
-      <div className="flex justify-center items-center gap-8 mb-8">
-        <img
-          src={logo}
-          alt="Bun Logo"
-          className="h-36 p-6 transition-all duration-300 hover:drop-shadow-[0_0_2em_#646cffaa] scale-120"
-        />
-        <img
-          src={reactLogo}
-          alt="React Logo"
-          className="h-36 p-6 transition-all duration-300 hover:drop-shadow-[0_0_2em_#61dafbaa] [animation:spin_20s_linear_infinite]"
-        />
-      </div>
-
-      <Card className="bg-card/50 backdrop-blur-sm border-muted">
-        <CardContent className="pt-6">
-          <h1 className="text-5xl font-bold my-4 leading-tight">Bun + React</h1>
-          <p>
-            Edit{" "}
-            <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm">src/App.tsx</code> and
-            save to test HMR
-          </p>
-          <APITester />
-          <div className="mt-4 text-center">
-            <button className="underline text-sm" onClick={() => setPage("matcher")}>Go to Gift Matcher</button>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <GiftMatcher />;
 }
 
 export default App;

--- a/src/GiftMatcher.tsx
+++ b/src/GiftMatcher.tsx
@@ -106,7 +106,7 @@ export function GiftMatcher({ onBack }: { onBack?: () => void } = {}) {
   };
 
   return (
-    <div className="container mx-auto p-8 relative z-10">
+    <div className="mx-auto p-8 relative z-10 w-full max-w-3xl">
       <h1 className="text-3xl font-bold mb-6 text-center">Angelito Matcher</h1>
       {onBack && (
         <button className="underline mb-4 text-sm" onClick={onBack}>
@@ -151,10 +151,19 @@ export function GiftMatcher({ onBack }: { onBack?: () => void } = {}) {
             <button className="underline text-sm" onClick={addPerson}>
               + Add person
             </button>
-            <Button size="lg" onClick={() => handleMatch()}>Match</Button>
           </div>
         </CardContent>
       </Card>
+
+      <div className="flex justify-center mt-6">
+        <Button
+          size="lg"
+          className="px-8 text-lg"
+          onClick={() => handleMatch()}
+        >
+          Match
+        </Button>
+      </div>
 
       {matches && (
         <Card className="bg-card/50 backdrop-blur-sm border-muted mt-4">

--- a/src/GiftMatcher.tsx
+++ b/src/GiftMatcher.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 
 const LOCAL_STORAGE_KEY = "giftMatcherData";
 
@@ -148,8 +149,9 @@ export function GiftMatcher({ onBack }: { onBack?: () => void } = {}) {
           ))}
 
           <div className="flex gap-4">
-            <button className="underline text-sm" onClick={addPerson}>
-              + Add person
+            <button className="underline text-sm flex items-center gap-1" onClick={addPerson}>
+              <Plus className="size-3.5" />
+              Add person
             </button>
           </div>
         </CardContent>

--- a/src/GiftMatcher.tsx
+++ b/src/GiftMatcher.tsx
@@ -1,13 +1,39 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
-export function GiftMatcher({ onBack }: { onBack: () => void }) {
+const LOCAL_STORAGE_KEY = "giftMatcherData";
+
+export function GiftMatcher({ onBack }: { onBack?: () => void } = {}) {
   const [persons, setPersons] = useState([{ name: "", email: "" }]);
   const [restrictionIndex, setRestrictionIndex] = useState<number | null>(null);
   const [restrictions, setRestrictions] = useState<Record<number, number[]>>({});
   const [matches, setMatches] = useState<number[] | null>(null);
+  const [amount, setAmount] = useState("");
   const [tempRestrictions, setTempRestrictions] = useState<number[]>([]);
+
+  // Load saved data on mount
+  useEffect(() => {
+    const raw = typeof localStorage !== "undefined" &&
+      localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      if (Array.isArray(data.persons)) setPersons(data.persons);
+      if (data.restrictions) setRestrictions(data.restrictions);
+      if (typeof data.amount === "string") setAmount(data.amount);
+    } catch (err) {
+      console.error("Failed to parse saved data", err);
+    }
+  }, []);
+
+  // Persist form data while editing
+  useEffect(() => {
+    if (matches) return; // don't save after matching
+    const data = JSON.stringify({ persons, restrictions, amount });
+    localStorage.setItem(LOCAL_STORAGE_KEY, data);
+  }, [persons, restrictions, amount, matches]);
 
   useEffect(() => {
     if (restrictionIndex !== null) {
@@ -61,12 +87,13 @@ export function GiftMatcher({ onBack }: { onBack: () => void }) {
       }
       if (valid) {
         setMatches(shuffled);
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
 
         try {
           await fetch("/api/sendEmails", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ persons, matches: shuffled }),
+            body: JSON.stringify({ persons, matches: shuffled, amount }),
           });
         } catch (err) {
           console.error(err);
@@ -80,15 +107,25 @@ export function GiftMatcher({ onBack }: { onBack: () => void }) {
 
   return (
     <div className="container mx-auto p-8 relative z-10">
-      <h2 className="text-3xl font-bold mb-6">
-        Angelito Matcher
-      </h2>
-      <button className="underline mb-4 text-sm" onClick={onBack}>
-        ← Back to Home
-      </button>
+      <h1 className="text-3xl font-bold mb-6 text-center">Angelito Matcher</h1>
+      {onBack && (
+        <button className="underline mb-4 text-sm" onClick={onBack}>
+          ← Back to Home
+        </button>
+      )}
 
       <Card className="bg-card/50 backdrop-blur-sm border-muted">
         <CardContent className="pt-6 flex flex-col gap-4">
+          <div className="flex items-end gap-2">
+            <span>RD$</span>
+            <Input
+              type="number"
+              placeholder="Monto"
+              value={amount}
+              onChange={e => setAmount(e.target.value)}
+              className="w-32"
+            />
+          </div>
           {persons.map((p, idx) => (
             <div key={idx} className="flex gap-2 items-end">
               <Input
@@ -112,11 +149,9 @@ export function GiftMatcher({ onBack }: { onBack: () => void }) {
 
           <div className="flex gap-4">
             <button className="underline text-sm" onClick={addPerson}>
-              Add person
+              + Add person
             </button>
-            <button className="underline text-sm" onClick={() => handleMatch()}>
-              Match
-            </button>
+            <Button size="lg" onClick={() => handleMatch()}>Match</Button>
           </div>
         </CardContent>
       </Card>

--- a/src/GiftMatcher.tsx
+++ b/src/GiftMatcher.tsx
@@ -107,7 +107,7 @@ export function GiftMatcher({ onBack }: { onBack?: () => void } = {}) {
   };
 
   return (
-    <div className="mx-auto p-8 relative z-10 w-full max-w-3xl">
+    <div className="container mx-auto p-8 relative z-10">
       <h1 className="text-3xl font-bold mb-6 text-center">Angelito Matcher</h1>
       {onBack && (
         <button className="underline mb-4 text-sm" onClick={onBack}>
@@ -153,32 +153,10 @@ export function GiftMatcher({ onBack }: { onBack?: () => void } = {}) {
               <Plus className="size-3.5" />
               Add person
             </button>
+            <Button size="lg" onClick={() => handleMatch()}>Match</Button>
           </div>
         </CardContent>
       </Card>
-
-      <div className="flex justify-center mt-6">
-        <Button
-          size="lg"
-          className="px-8 text-lg"
-          onClick={() => handleMatch()}
-        >
-          Match
-        </Button>
-      </div>
-
-      {matches && (
-        <Card className="bg-card/50 backdrop-blur-sm border-muted mt-4">
-          <CardContent className="pt-6 space-y-2">
-            {matches.map((toIdx, fromIdx) => (
-              <p key={fromIdx}>
-                {(persons[fromIdx].name || `Person ${fromIdx + 1}`)} →{' '}
-                {(persons[toIdx].name || `Person ${toIdx + 1}`)}
-              </p>
-            ))}
-          </CardContent>
-        </Card>
-      )}
 
       {restrictionIndex !== null && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center">

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="./logo.svg" />
-    <title>Bun + React</title>
+    <title>Angelito Matcher</title>
     <script type="module" src="./frontend.tsx" async></script>
   </head>
   <body>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,11 +26,12 @@ const server = serve({
 
     "/api/sendEmails": async req => {
       try {
-        const { persons, matches } = await req.json();
+        const { persons, matches, amount } = await req.json();
 
         if (!Array.isArray(persons) || !Array.isArray(matches)) {
           return new Response("Invalid payload", { status: 400 });
         }
+        const giftAmount = Number(amount) || 0;
 
         console.log("Sending emails to:", persons.length, "recipients");
 
@@ -49,7 +50,7 @@ const server = serve({
                 from: "angelitomatcher@emiliofont.dev",
                 to: recipient.email,
                 subject: "Tu angelito",
-                html: `<p>Hola, tu angelito es ${match.name}</p>`,
+                html: `<p>Hola, tu angelito es ${match.name}. El monto del regalo es RD$${giftAmount}</p>`,
               });
               console.log(`Email sent to ${recipient.email}`);
             } catch (error) {


### PR DESCRIPTION
## Summary
- keep GiftMatcher state in localStorage so the form survives refreshes
- clear the saved state once a match is generated
- show Angelito Matcher page by default with updated title
- include gift amount in email payload

## Testing
- `bun run build.ts` *(fails: Cannot find package 'bun-plugin-tailwind')*

------
https://chatgpt.com/codex/tasks/task_e_68618803414c8333a871df7053ec83da