### PR TITLE
chore: log auth cookies

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -71,6 +71,10 @@ export default {
                 return new Response(null, { status: 204, headers: cors(origin) });
             }
 
+            // Log incoming cookies for debugging auth callbacks
+            const incomingCookies = request.headers.get("cookie");
+            console.log("auth request cookies for", url.pathname, ":", incomingCookies);
+
             // IMPORTANT: don’t read/consume the body here
             const res = await auth.handler(request);
 


### PR DESCRIPTION
## Summary
- log incoming cookie header on `/api/auth` requests to inspect callback cookies

## Testing
- `npm test`
- `npm run lint` *(fails: numerous lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f6c307948333bdacb7daf03f4223